### PR TITLE
Add Component descriptions to ReadMe.Md | NotificationIcon update

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ VUE_APP_MAPBOX_KEY=/your key here/
 ## Reusable component descriptions
 
 ### Notification Icon
+The notification icon component is an icon that displays a tooltip upon hover.
+ 
 | Name | Type | Description|Values
 |------|------|------------|-----|
 |Icon|String|The material icon to display|&lt;any material icon name&gt;|

--- a/README.md
+++ b/README.md
@@ -29,3 +29,14 @@ VUE_APP_CENTER_LAT=33.4515
 VUE_APP_CENTER_LNG=-112.07 // central phoenix
 VUE_APP_MAPBOX_KEY=/your key here/
 ```
+---
+
+# Components
+## Reusable component descriptions
+
+### Notification Icon
+| Name | Type | Description|Values
+|------|------|------------|-----|
+|Icon|String|The material icon to display|&lt;any material icon name&gt;|
+|Message|String|Message is displayed in a tooltip when the user hovers the icon|&lt;any&gt;|
+|Level|String|The [Bulma color](https://bulma.io/documentation/overview/modifiers/) for the icon|"info", "warning", "error", "success", "primary", "link"|

--- a/src/components/reusable/NotificationIcon.vue
+++ b/src/components/reusable/NotificationIcon.vue
@@ -20,7 +20,14 @@ export default {
       type: String,
       required: true,
       validator: value => {
-        return ["info", "warning", "error", "success"].includes(value);
+        return [
+          "info",
+          "warning",
+          "error",
+          "success",
+          "primary",
+          "link"
+        ].includes(value);
       }
     }
   }


### PR DESCRIPTION
1. Add a section to ReadMe.Md to document reusable components.
2. Add the other Bulma primary colors to the NotificationIcon component 